### PR TITLE
Update minSdk version in app/build.gradle to 21

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -48,8 +48,8 @@ android {
         applicationId "com.example.eshop.eshop"
         // You can update the following values to match your application needs.
         // For more information, see: https://docs.flutter.dev/deployment/android#reviewing-the-gradle-build-configuration.
-        minSdkVersion localProperties.getProperty('flutter.minSdkVersion').toInteger()
-        targetSdkVersion localProperties.getProperty('flutter.targetSdkVersion').toInteger()
+        minSdkVersion 21
+        targetSdkVersion flutter.targetSdkVersion
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
     }


### PR DESCRIPTION
The primary change involves the minSdkVersion in the app/build.gradle file, which has been set to a fixed value of 21 (Android 5.0 Lollipop). This modification was necessary to align our application with the requirements and features offered by Android 5.0 and later versions.