### PR TITLE
Update: app/build.gradle compile sdk verion

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -27,7 +27,7 @@ apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
     namespace "com.example.eshop.eshop"
-    compileSdkVersion localProperties.getProperty('flutter.compileSdkVersion').toInteger()
+    compileSdkVersion flutter.compileSdkVersion
     ndkVersion flutter.ndkVersion
 
     compileOptions {


### PR DESCRIPTION
The primary change involves the compileSdkVersion value in the app/build.gradle file, which has been updated to a new version.